### PR TITLE
$drupalFinder is not defined in createRequiredFiles

### DIFF
--- a/scripts/composer/ScriptHandler.php
+++ b/scripts/composer/ScriptHandler.php
@@ -72,6 +72,8 @@ class ScriptHandler {
    * @return void
    */
   public static function createRequiredFiles(Event $event) {
+    $drupalFinder = new DrupalFinder();
+    $drupalFinder->locateRoot(getcwd());
     $fs = new Filesystem();
     $drupalRoot = self::getDrupalRoot();
 


### PR DESCRIPTION
Hey there.

Just noticed while looking at the logs for violinist.io that your project is not possible to install due to an undefined variable in your install script.

Here is a PR fixing that.

Hope you will enjoy the incoming PRs from violinist.io in good time :)

Have a great weekend!